### PR TITLE
Fix invalid lvalue COLS, LINES assignemnt

### DIFF
--- a/cmatrix.c
+++ b/cmatrix.c
@@ -79,6 +79,10 @@ cmatrix **matrix = (cmatrix **) NULL;
 int *length = NULL;  /* Length of cols in each line */
 int *spaces = NULL;  /* Spaces left to fill */
 int *updates = NULL; /* What does this do again? */
+
+int cmatrix_lines;  /* The number of terminal lines */
+int cmatrix_cols;   /* The number of terminal columns */
+
 #ifndef _WIN32
 volatile sig_atomic_t signal_status = 0; /* Indicates a caught signal */
 #endif
@@ -274,15 +278,15 @@ void resize_screen(void) {
         return;
     }
 
-    COLS = win.ws_col;
-    LINES = win.ws_row;
+    cmatrix_cols = win.ws_col;
+    cmatrix_lines = win.ws_row;
 #endif
 
     if(LINES <10){
-        LINES = 10;
+        cmatrix_lines = 10;
     }
     if(COLS <10){
-        COLS = 10;
+        cmatrix_cols = 10;
     }
 
 #ifdef HAVE_RESIZETERM


### PR DESCRIPTION
Fixes invalid lvalue assigment that was breaking the build on openSUSE.
Tested only on openSUSE Tumbleweed.